### PR TITLE
Support nimble_parsec ~> 1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,7 @@ defmodule UnicodeSet.MixProject do
   defp deps do
     [
       {:ex_unicode, "~> 1.8"},
-      {:nimble_parsec, "~> 0.5", runtime: false},
+      {:nimble_parsec, "~> 0.5 or ~> 1.0", runtime: false},
       {:benchee, "~> 1.0", only: :dev},
       {:ex_doc, "~> 0.19", only: [:dev, :test, :release], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false, optional: true}


### PR DESCRIPTION
We want to use unicode_set on makeup_elixir but we also need nimble_parsec 1.0+, so I supported both new and old requirements. nimble_parsec 1.0 should be compatible with both 0.5 and 0.6.

If you could release a new version after merge, it would be very appreciated. :)